### PR TITLE
Arithmetic operators on images

### DIFF
--- a/benches/image_access.rs
+++ b/benches/image_access.rs
@@ -15,7 +15,7 @@ mod bench_ndimage {
     use ndimage::core::{Image2D, Image2DMut, ImageBuffer2D, Luma, Rect};
 
     #[bench]
-    fn ndimage_fill_gray(b: &mut Bencher) {
+    fn fill_gray(b: &mut Bencher) {
         let mut img = ImageBuffer2D::<Luma<u8>>::new(W, H);
         b.iter(|| {
             img.fill(&Luma::new([127]));
@@ -23,7 +23,7 @@ mod bench_ndimage {
     }
 
     #[bench]
-    fn ndimage_fill_loop_gray(b: &mut Bencher) {
+    fn fill_loop_gray(b: &mut Bencher) {
         let mut img = ImageBuffer2D::new(W, H);
         b.iter(|| {
             for y in 0..H {
@@ -35,7 +35,7 @@ mod bench_ndimage {
     }
 
     #[bench]
-    fn ndimage_fill_iter_gray(b: &mut Bencher) {
+    fn fill_iter_gray(b: &mut Bencher) {
         let mut img = ImageBuffer2D::<Luma<u8>>::new(W, H);
         b.iter(|| {
             for pix in &mut img {
@@ -45,7 +45,7 @@ mod bench_ndimage {
     }
 
     #[bench]
-    fn ndimage_fill_rect_iter_gray(b: &mut Bencher) {
+    fn fill_rect_iter_gray(b: &mut Bencher) {
         let r = Rect::new(320, 180, 1280, 720);
         let mut img = ImageBuffer2D::<Luma<u8>>::new(W, H);
         b.iter(|| {
@@ -56,7 +56,7 @@ mod bench_ndimage {
     }
 
     #[bench]
-    fn ndimage_fill_sub_image_gray(b: &mut Bencher) {
+    fn fill_sub_gray(b: &mut Bencher) {
         let r = Rect::new(320, 180, 1280, 720);
         let mut img = ImageBuffer2D::<Luma<u8>>::new(W, H);
         b.iter(|| {
@@ -82,7 +82,7 @@ mod bench_image {
     use image::{GenericImage, GrayImage, Luma};
 
     #[bench]
-    fn image_fill_loop_gray(b: &mut Bencher) {
+    fn fill_loop_gray(b: &mut Bencher) {
         let mut img = GrayImage::new(W, H);
         b.iter(|| {
             for y in 0..H {
@@ -94,7 +94,7 @@ mod bench_image {
     }
 
     #[bench]
-    fn image_fill_loop_gray_unsafe(b: &mut Bencher) {
+    fn fill_loop_gray_unsafe(b: &mut Bencher) {
         let mut img = GrayImage::new(W, H);
         b.iter(|| {
             for y in 0..H {
@@ -108,7 +108,7 @@ mod bench_image {
     }
 
     #[bench]
-    fn image_fill_iter_gray(b: &mut Bencher) {
+    fn fill_iter_gray(b: &mut Bencher) {
         let mut img = GrayImage::new(W, H);
         b.iter(|| {
             for pix in img.pixels_mut() {
@@ -119,7 +119,7 @@ mod bench_image {
 
     #[bench]
     #[allow(deprecated)]
-    fn image_fill_sub_image_gray(b: &mut Bencher) {
+    fn fill_sub_image_gray(b: &mut Bencher) {
         let mut img = GrayImage::new(W, H);
         b.iter(|| {
             for (_x, _y, pix) in img.sub_image(320, 180, 1280, 720).pixels_mut() {

--- a/benches/image_access.rs
+++ b/benches/image_access.rs
@@ -18,7 +18,7 @@ mod bench_ndimage {
     fn ndimage_fill_gray(b: &mut Bencher) {
         let mut img = ImageBuffer2D::<Luma<u8>>::new(W, H);
         b.iter(|| {
-            img.fill(Luma::new([127]));
+            img.fill(&Luma::new([127]));
         });
     }
 
@@ -67,9 +67,9 @@ mod bench_ndimage {
         for y in 0..H {
             for x in 0..W {
                 if x < 320 || y < 180 || x >= 1600 || y >= 900 {
-                    assert_eq!(img.get_pixel(x, y), Luma::new([0]));
+                    assert_eq!(img.get_pixel(x, y), &Luma::new([0]));
                 } else {
-                    assert_eq!(img.get_pixel(x, y), Luma::new([127]));
+                    assert_eq!(img.get_pixel(x, y), &Luma::new([127]));
                 }
             }
         }

--- a/benches/image_arithm.rs
+++ b/benches/image_arithm.rs
@@ -12,13 +12,13 @@ const W: u32 = 1920;
 const H: u32 = 1080;
 
 use num_traits::{Bounded, One};
-use rand::{thread_rng, Rng, distributions::Uniform};
+use rand::{thread_rng, distributions::{Distribution, Standard, Uniform, uniform::SampleUniform}};
 use test::Bencher;
 
 #[cfg(test)]
 mod bench_ndimage {
     use super::*;
-    use ndimage::core::{Image2D, Image2DMut, ImageBuffer2D, Luma, Rect, Pixel};
+    use ndimage::core::{Image2D, ImageBuffer2D, Luma, Pixel};
 
     macro_rules! gen_benches {
         ($name:ident, $pix:ty) => {
@@ -26,7 +26,7 @@ mod bench_ndimage {
                 use super::*;
 
                 #[bench]
-                fn ndimage_add_imagebuffer2d(b: &mut Bencher) {
+                fn add_imagebuffer2d(b: &mut Bencher) {
                     let img1 = ImageBuffer2D::<$pix>::rand(W, H, &mut thread_rng());
                     let img2 = ImageBuffer2D::<$pix>::rand(W, H, &mut thread_rng());
                     b.iter(|| {
@@ -35,7 +35,7 @@ mod bench_ndimage {
                 }
 
                 #[bench]
-                fn ndimage_add_image2d(b: &mut Bencher) {
+                fn add_image2d(b: &mut Bencher) {
                     let imgbuf1 = ImageBuffer2D::<$pix>::rand(W, H, &mut thread_rng());
                     let imgbuf2 = ImageBuffer2D::<$pix>::rand(W, H, &mut thread_rng());
 
@@ -46,7 +46,7 @@ mod bench_ndimage {
                     });
                 }
                 #[bench]
-                fn ndimage_sub_imagebuffer2d(b: &mut Bencher) {
+                fn sub_imagebuffer2d(b: &mut Bencher) {
                     let img1 = ImageBuffer2D::<$pix>::rand(W, H, &mut thread_rng());
                     let img2 = ImageBuffer2D::<$pix>::rand(W, H, &mut thread_rng());
                     b.iter(|| {
@@ -55,7 +55,7 @@ mod bench_ndimage {
                 }
 
                 #[bench]
-                fn ndimage_sub_image2d(b: &mut Bencher) {
+                fn sub_image2d(b: &mut Bencher) {
                     let imgbuf1 = ImageBuffer2D::<$pix>::rand(W, H, &mut thread_rng());
                     let imgbuf2 = ImageBuffer2D::<$pix>::rand(W, H, &mut thread_rng());
 
@@ -66,7 +66,7 @@ mod bench_ndimage {
                     });
                 }
                 #[bench]
-                fn ndimage_mul_imagebuffer2d(b: &mut Bencher) {
+                fn mul_imagebuffer2d(b: &mut Bencher) {
                     let img1 = ImageBuffer2D::<$pix>::rand(W, H, &mut thread_rng());
                     let img2 = ImageBuffer2D::<$pix>::rand(W, H, &mut thread_rng());
                     b.iter(|| {
@@ -75,7 +75,7 @@ mod bench_ndimage {
                 }
 
                 #[bench]
-                fn ndimage_mul_image2d(b: &mut Bencher) {
+                fn mul_image2d(b: &mut Bencher) {
                     let imgbuf1 = ImageBuffer2D::<$pix>::rand(W, H, &mut thread_rng());
                     let imgbuf2 = ImageBuffer2D::<$pix>::rand(W, H, &mut thread_rng());
 
@@ -86,7 +86,7 @@ mod bench_ndimage {
                     });
                 }
                 #[bench]
-                fn ndimage_div_imagebuffer2d(b: &mut Bencher) {
+                fn div_imagebuffer2d(b: &mut Bencher) {
                     let d = Uniform::new(<<$pix as Pixel>::Subpixel as Bounded>::min_value() + <<$pix as Pixel>::Subpixel as One>::one(), <<$pix as Pixel>::Subpixel as Bounded>::max_value());
                     let img1 = ImageBuffer2D::<$pix>::rand_with_distr(W, H, &mut thread_rng(), &d);
                     let img2 = ImageBuffer2D::<$pix>::rand_with_distr(W, H, &mut thread_rng(), &d);
@@ -97,7 +97,7 @@ mod bench_ndimage {
                 }
 
                 #[bench]
-                fn ndimage_div_image2d(b: &mut Bencher) {
+                fn div_image2d(b: &mut Bencher) {
                     let d = Uniform::new(<<$pix as Pixel>::Subpixel as Bounded>::min_value() + <<$pix as Pixel>::Subpixel as One>::one(), <<$pix as Pixel>::Subpixel as Bounded>::max_value());
                     let imgbuf1 = ImageBuffer2D::<$pix>::rand_with_distr(W, H, &mut thread_rng(), &d);
                     let imgbuf2 = ImageBuffer2D::<$pix>::rand_with_distr(W, H, &mut thread_rng(), &d);
@@ -110,7 +110,7 @@ mod bench_ndimage {
                 }
 
                 #[bench]
-                fn ndimage_rem_imagebuffer2d(b: &mut Bencher) {
+                fn rem_imagebuffer2d(b: &mut Bencher) {
                     let d = Uniform::new(<<$pix as Pixel>::Subpixel as Bounded>::min_value() + <<$pix as Pixel>::Subpixel as One>::one(), <<$pix as Pixel>::Subpixel as Bounded>::max_value());
                     let img1 = ImageBuffer2D::<$pix>::rand_with_distr(W, H, &mut thread_rng(), &d);
                     let img2 = ImageBuffer2D::<$pix>::rand_with_distr(W, H, &mut thread_rng(), &d);
@@ -121,7 +121,7 @@ mod bench_ndimage {
                 }
 
                 #[bench]
-                fn ndimage_rem_image2d(b: &mut Bencher) {
+                fn rem_image2d(b: &mut Bencher) {
                     let d = Uniform::new(<<$pix as Pixel>::Subpixel as Bounded>::min_value() + <<$pix as Pixel>::Subpixel as One>::one(), <<$pix as Pixel>::Subpixel as Bounded>::max_value());
                     let imgbuf1 = ImageBuffer2D::<$pix>::rand_with_distr(W, H, &mut thread_rng(), &d);
                     let imgbuf2 = ImageBuffer2D::<$pix>::rand_with_distr(W, H, &mut thread_rng(), &d);
@@ -144,9 +144,14 @@ mod bench_ndimage {
 #[cfg(test)]
 mod bench_image {
     use super::*;
-    use image::{GenericImage, GrayImage, Luma, ImageBuffer, Pixel, Primitive};
+    use image::{Luma, ImageBuffer, Primitive};
 
-    fn generate_luma(width: u32, height: u32) -> ImageBuffer<Luma<u8>, Vec<u8>>
+    use rand::Rng;
+
+    fn generate_luma<S>(width: u32, height: u32) -> ImageBuffer<Luma<S>, Vec<S>>
+    where
+        S: Primitive + 'static,
+        Standard: Distribution<S>
     {
         let mut rng = thread_rng();
         let mut img = ImageBuffer::new(width, height);
@@ -156,17 +161,96 @@ mod bench_image {
         img
     }
 
-    #[bench]
-    fn image_add_imagebuffer_luma_u8(b: &mut Bencher) {
-        let img1 = generate_luma(W, H);
-        let img2 = generate_luma(W, H);
-        b.iter(|| {
-            let mut img = ImageBuffer::new(W, H);
-            for ((p1, p2), p) in img1.pixels().zip(img2.pixels()).zip(img.pixels_mut()) {
-                *p = Luma { data: [p1[0] + p2[0]] }
-            }
-        });
+    fn generate_luma_nonzero<S>(width: u32, height: u32) -> ImageBuffer<Luma<S>, Vec<S>>
+    where
+        S: Primitive + SampleUniform + Bounded + 'static,
+        Standard: Distribution<S>
+    {
+        let distr = Uniform::new(<S as One>::one(), <S as Bounded>::max_value());
+        let mut rng = thread_rng();
+        let mut img = ImageBuffer::new(width, height);
+        for pix in img.pixels_mut() {
+            *pix = Luma { data: [rng.sample(&distr)] }
+        }
+        img
     }
+
+    macro_rules! gen_benches_luma {
+        ($name:ident, $subpix:ty) => {
+            mod $name {
+                use super::*;
+
+                #[bench]
+                fn add_imagebuffer2d(b: &mut Bencher) {
+                    let img1 = generate_luma::<$subpix>(W, H);
+                    let img2 = generate_luma::<$subpix>(W, H);
+
+                    b.iter(|| {
+                        let mut img = ImageBuffer::new(W, H);
+                        for ((p1, p2), p) in img1.pixels().zip(img2.pixels()).zip(img.pixels_mut()) {
+                            *p = Luma { data: [p1[0] + p2[0]] };
+                        }
+                    });
+                }
+
+                #[bench]
+                fn sub_image2d(b: &mut Bencher) {
+                    let img1 = generate_luma::<$subpix>(W, H);
+                    let img2 = generate_luma::<$subpix>(W, H);
+
+                    b.iter(|| {
+                        let mut img = ImageBuffer::new(W, H);
+                        for ((p1, p2), p) in img1.pixels().zip(img2.pixels()).zip(img.pixels_mut()) {
+                            *p = Luma { data: [p1[0] - p2[0]] }
+                        }
+                    });
+                }
+
+                #[bench]
+                fn mul_imagebuffer2d(b: &mut Bencher) {
+                    let img1 = generate_luma::<$subpix>(W, H);
+                    let img2 = generate_luma::<$subpix>(W, H);
+
+                    b.iter(|| {
+                        let mut img = ImageBuffer::new(W, H);
+                        for ((p1, p2), p) in img1.pixels().zip(img2.pixels()).zip(img.pixels_mut()) {
+                            *p = Luma { data: [p1[0] * p2[0]] }
+                        }
+                    });
+                }
+
+                #[bench]
+                fn div_imagebuffer2d(b: &mut Bencher) {
+                    let img1 = generate_luma_nonzero::<$subpix>(W, H);
+                    let img2 = generate_luma_nonzero::<$subpix>(W, H);
+
+                    b.iter(|| {
+                        let mut img = ImageBuffer::new(W, H);
+                        for ((p1, p2), p) in img1.pixels().zip(img2.pixels()).zip(img.pixels_mut()) {
+                            *p = Luma { data: [p1[0] / p2[0]] }
+                        }
+                    });
+                }
+
+                #[bench]
+                fn rem_imagebuffer2d(b: &mut Bencher) {
+                    let img1 = generate_luma_nonzero::<$subpix>(W, H);
+                    let img2 = generate_luma_nonzero::<$subpix>(W, H);
+
+                    b.iter(|| {
+                        let mut img = ImageBuffer::new(W, H);
+                        for ((p1, p2), p) in img1.pixels().zip(img2.pixels()).zip(img.pixels_mut()) {
+                            *p = Luma { data: [p1[0] % p2[0]] }
+                        }
+                    });
+                }
+            }
+        }
+    }
+
+    gen_benches_luma!(luma_u8, u8);
+    gen_benches_luma!(luma_u32, u32);
+    gen_benches_luma!(luma_f32, f32);
 }
 
 }

--- a/benches/image_arithm.rs
+++ b/benches/image_arithm.rs
@@ -1,0 +1,172 @@
+#![feature(test)]
+
+extern crate image;
+extern crate ndimage;
+extern crate num_traits;
+extern crate rand;
+extern crate test;
+
+mod bench_arithm {
+
+const W: u32 = 1920;
+const H: u32 = 1080;
+
+use num_traits::{Bounded, One};
+use rand::{thread_rng, Rng, distributions::Uniform};
+use test::Bencher;
+
+#[cfg(test)]
+mod bench_ndimage {
+    use super::*;
+    use ndimage::core::{Image2D, Image2DMut, ImageBuffer2D, Luma, Rect, Pixel};
+
+    macro_rules! gen_benches {
+        ($name:ident, $pix:ty) => {
+            mod $name {
+                use super::*;
+
+                #[bench]
+                fn ndimage_add_imagebuffer2d(b: &mut Bencher) {
+                    let img1 = ImageBuffer2D::<$pix>::rand(W, H, &mut thread_rng());
+                    let img2 = ImageBuffer2D::<$pix>::rand(W, H, &mut thread_rng());
+                    b.iter(|| {
+                        let _ = (&img1 + &img2).unwrap();
+                    });
+                }
+
+                #[bench]
+                fn ndimage_add_image2d(b: &mut Bencher) {
+                    let imgbuf1 = ImageBuffer2D::<$pix>::rand(W, H, &mut thread_rng());
+                    let imgbuf2 = ImageBuffer2D::<$pix>::rand(W, H, &mut thread_rng());
+
+                    let img1: &Image2D<_> = &imgbuf1;
+                    let img2: &Image2D<_> = &imgbuf2;
+                    b.iter(|| {
+                        let _ = (img1 + img2).unwrap();
+                    });
+                }
+                #[bench]
+                fn ndimage_sub_imagebuffer2d(b: &mut Bencher) {
+                    let img1 = ImageBuffer2D::<$pix>::rand(W, H, &mut thread_rng());
+                    let img2 = ImageBuffer2D::<$pix>::rand(W, H, &mut thread_rng());
+                    b.iter(|| {
+                        let _ = (&img1 - &img2).unwrap();
+                    });
+                }
+
+                #[bench]
+                fn ndimage_sub_image2d(b: &mut Bencher) {
+                    let imgbuf1 = ImageBuffer2D::<$pix>::rand(W, H, &mut thread_rng());
+                    let imgbuf2 = ImageBuffer2D::<$pix>::rand(W, H, &mut thread_rng());
+
+                    let img1: &Image2D<_> = &imgbuf1;
+                    let img2: &Image2D<_> = &imgbuf2;
+                    b.iter(|| {
+                        let _ = (img1 - img2).unwrap();
+                    });
+                }
+                #[bench]
+                fn ndimage_mul_imagebuffer2d(b: &mut Bencher) {
+                    let img1 = ImageBuffer2D::<$pix>::rand(W, H, &mut thread_rng());
+                    let img2 = ImageBuffer2D::<$pix>::rand(W, H, &mut thread_rng());
+                    b.iter(|| {
+                        let _ = (&img1 * &img2).unwrap();
+                    });
+                }
+
+                #[bench]
+                fn ndimage_mul_image2d(b: &mut Bencher) {
+                    let imgbuf1 = ImageBuffer2D::<$pix>::rand(W, H, &mut thread_rng());
+                    let imgbuf2 = ImageBuffer2D::<$pix>::rand(W, H, &mut thread_rng());
+
+                    let img1: &Image2D<_> = &imgbuf1;
+                    let img2: &Image2D<_> = &imgbuf2;
+                    b.iter(|| {
+                        let _ = (img1 * img2).unwrap();
+                    });
+                }
+                #[bench]
+                fn ndimage_div_imagebuffer2d(b: &mut Bencher) {
+                    let d = Uniform::new(<<$pix as Pixel>::Subpixel as Bounded>::min_value() + <<$pix as Pixel>::Subpixel as One>::one(), <<$pix as Pixel>::Subpixel as Bounded>::max_value());
+                    let img1 = ImageBuffer2D::<$pix>::rand_with_distr(W, H, &mut thread_rng(), &d);
+                    let img2 = ImageBuffer2D::<$pix>::rand_with_distr(W, H, &mut thread_rng(), &d);
+
+                    b.iter(|| {
+                        let _ = (&img1 / &img2).unwrap();
+                    });
+                }
+
+                #[bench]
+                fn ndimage_div_image2d(b: &mut Bencher) {
+                    let d = Uniform::new(<<$pix as Pixel>::Subpixel as Bounded>::min_value() + <<$pix as Pixel>::Subpixel as One>::one(), <<$pix as Pixel>::Subpixel as Bounded>::max_value());
+                    let imgbuf1 = ImageBuffer2D::<$pix>::rand_with_distr(W, H, &mut thread_rng(), &d);
+                    let imgbuf2 = ImageBuffer2D::<$pix>::rand_with_distr(W, H, &mut thread_rng(), &d);
+
+                    let img1: &Image2D<_> = &imgbuf1;
+                    let img2: &Image2D<_> = &imgbuf2;
+                    b.iter(|| {
+                        let _ = (img1 / img2).unwrap();
+                    });
+                }
+
+                #[bench]
+                fn ndimage_rem_imagebuffer2d(b: &mut Bencher) {
+                    let d = Uniform::new(<<$pix as Pixel>::Subpixel as Bounded>::min_value() + <<$pix as Pixel>::Subpixel as One>::one(), <<$pix as Pixel>::Subpixel as Bounded>::max_value());
+                    let img1 = ImageBuffer2D::<$pix>::rand_with_distr(W, H, &mut thread_rng(), &d);
+                    let img2 = ImageBuffer2D::<$pix>::rand_with_distr(W, H, &mut thread_rng(), &d);
+
+                    b.iter(|| {
+                        let _ = (&img1 % &img2).unwrap();
+                    });
+                }
+
+                #[bench]
+                fn ndimage_rem_image2d(b: &mut Bencher) {
+                    let d = Uniform::new(<<$pix as Pixel>::Subpixel as Bounded>::min_value() + <<$pix as Pixel>::Subpixel as One>::one(), <<$pix as Pixel>::Subpixel as Bounded>::max_value());
+                    let imgbuf1 = ImageBuffer2D::<$pix>::rand_with_distr(W, H, &mut thread_rng(), &d);
+                    let imgbuf2 = ImageBuffer2D::<$pix>::rand_with_distr(W, H, &mut thread_rng(), &d);
+
+                    let img1: &Image2D<_> = &imgbuf1;
+                    let img2: &Image2D<_> = &imgbuf2;
+                    b.iter(|| {
+                        let _ = (img1 % img2).unwrap();
+                    });
+                }
+            }
+        }
+    }
+
+    gen_benches!(luma_u8, Luma<u8>);
+    gen_benches!(luma_u32, Luma<u32>);
+    gen_benches!(luma_f32, Luma<f32>);
+}
+
+#[cfg(test)]
+mod bench_image {
+    use super::*;
+    use image::{GenericImage, GrayImage, Luma, ImageBuffer, Pixel, Primitive};
+
+    fn generate_luma(width: u32, height: u32) -> ImageBuffer<Luma<u8>, Vec<u8>>
+    {
+        let mut rng = thread_rng();
+        let mut img = ImageBuffer::new(width, height);
+        for pix in img.pixels_mut() {
+            *pix = Luma { data: [rng.gen()] }
+        }
+        img
+    }
+
+    #[bench]
+    fn image_add_imagebuffer_luma_u8(b: &mut Bencher) {
+        let img1 = generate_luma(W, H);
+        let img2 = generate_luma(W, H);
+        b.iter(|| {
+            let mut img = ImageBuffer::new(W, H);
+            for ((p1, p2), p) in img1.pixels().zip(img2.pixels()).zip(img.pixels_mut()) {
+                *p = Luma { data: [p1[0] + p2[0]] }
+            }
+        });
+    }
+}
+
+}

--- a/src/core/pixel_types.rs
+++ b/src/core/pixel_types.rs
@@ -1,7 +1,7 @@
 //! Contains the definitions of the various pixel types defined in this crate.
 
 use num_traits::cast::cast;
-use num_traits::{One, Zero};
+use num_traits::{Bounded, One, Zero};
 #[cfg(feature = "rand_integration")]
 use rand::{
     distributions::{Distribution, Standard},
@@ -88,6 +88,48 @@ macro_rules! impl_pixels {
             }
         }
 
+        impl<'a, P> Add<$name<P>> for &'a $name<P>
+            where P: Primitive
+        {
+            type Output = $name<P>;
+
+            fn add(self, rhs: $name<P>) -> $name<P> {
+                let mut data = [<P as Zero>::zero(); $n_channels];
+                for ((n, s), r) in data.iter_mut().zip(self.data.iter()).zip(rhs.data.iter()) {
+                    *n = *s + *r;
+                }
+                $name { data }
+            }
+        }
+
+        impl<'a, P> Add<&'a $name<P>> for $name<P>
+            where P: Primitive
+        {
+            type Output = $name<P>;
+
+            fn add(self, rhs: &'a $name<P>) -> $name<P> {
+                let mut data = [<P as Zero>::zero(); $n_channels];
+                for ((n, s), r) in data.iter_mut().zip(self.data.iter()).zip(rhs.data.iter()) {
+                    *n = *s + *r;
+                }
+                $name { data }
+            }
+        }
+
+        impl<'a, 'b, P> Add<&'a $name<P>> for &'b $name<P>
+            where P: Primitive
+        {
+            type Output = $name<P>;
+
+            fn add(self, rhs: &'a $name<P>) -> $name<P> {
+                let mut data = [<P as Zero>::zero(); $n_channels];
+                for ((n, s), r) in data.iter_mut().zip(self.data.iter()).zip(rhs.data.iter()) {
+                    *n = *s + *r;
+                }
+                $name { data }
+            }
+        }
+
         impl<P> Sub for $name<P>
             where P: Primitive
         {
@@ -102,12 +144,40 @@ macro_rules! impl_pixels {
             }
         }
 
-        impl<'a, 'b, P> Sub<&'b $name<P>> for &'a $name<P>
+        impl<'a, P> Sub<$name<P>> for &'a $name<P>
             where P: Primitive
         {
             type Output = $name<P>;
 
-            fn sub(self, rhs: &'b $name<P>) -> $name<P> {
+            fn sub(self, rhs: $name<P>) -> $name<P> {
+                let mut data = [<P as Zero>::zero(); $n_channels];
+                for ((n, s), r) in data.iter_mut().zip(self.data.iter()).zip(rhs.data.iter()) {
+                    *n = *s - *r;
+                }
+                $name { data }
+            }
+        }
+
+        impl<'a, P> Sub<&'a $name<P>> for $name<P>
+            where P: Primitive
+        {
+            type Output = $name<P>;
+
+            fn sub(self, rhs: &'a $name<P>) -> $name<P> {
+                let mut data = [<P as Zero>::zero(); $n_channels];
+                for ((n, s), r) in data.iter_mut().zip(self.data.iter()).zip(rhs.data.iter()) {
+                    *n = *s - *r;
+                }
+                $name { data }
+            }
+        }
+
+        impl<'a, 'b, P> Sub<&'a $name<P>> for &'b $name<P>
+            where P: Primitive
+        {
+            type Output = $name<P>;
+
+            fn sub(self, rhs: &'a $name<P>) -> $name<P> {
                 let mut data = [<P as Zero>::zero(); $n_channels];
                 for ((n, s), r) in data.iter_mut().zip(self.data.iter()).zip(rhs.data.iter()) {
                     *n = *s - *r;
@@ -130,19 +200,47 @@ macro_rules! impl_pixels {
             }
         }
 
-        //impl<'a, P> Mul for &'a $name<P>
-            //where P: Primitive
-        //{
-            //type Output = $name<P>;
+        impl<'a, P> Mul<$name<P>> for &'a $name<P>
+            where P: Primitive
+        {
+            type Output = $name<P>;
 
-            //fn mul(&'a self, &'a rhs: $name<P>) -> $name<P> {
-                //let mut data = [<P as Zero>::zero(); $n_channels];
-                //for i in 0..$n_channels {
-                    //data[i] = self.data[i] * rhs.data[i];
-                //}
-                //$name { data: data }
-            //}
-        //}
+            fn mul(self, rhs: $name<P>) -> $name<P> {
+                let mut data = [<P as Zero>::zero(); $n_channels];
+                for ((n, s), r) in data.iter_mut().zip(self.data.iter()).zip(rhs.data.iter()) {
+                    *n = *s * *r;
+                }
+                $name { data }
+            }
+        }
+
+        impl<'a, P> Mul<&'a $name<P>> for $name<P>
+            where P: Primitive
+        {
+            type Output = $name<P>;
+
+            fn mul(self, rhs: &'a $name<P>) -> $name<P> {
+                let mut data = [<P as Zero>::zero(); $n_channels];
+                for ((n, s), r) in data.iter_mut().zip(self.data.iter()).zip(rhs.data.iter()) {
+                    *n = *s * *r;
+                }
+                $name { data }
+            }
+        }
+
+        impl<'a, 'b, P> Mul<&'a $name<P>> for &'b $name<P>
+            where P: Primitive
+        {
+            type Output = $name<P>;
+
+            fn mul(self, rhs: &'a $name<P>) -> $name<P> {
+                let mut data = [<P as Zero>::zero(); $n_channels];
+                for ((n, s), r) in data.iter_mut().zip(self.data.iter()).zip(rhs.data.iter()) {
+                    *n = *s * *r;
+                }
+                $name { data }
+            }
+        }
 
         impl<P> Div for $name<P>
             where P: Primitive
@@ -158,12 +256,96 @@ macro_rules! impl_pixels {
             }
         }
 
+        impl<'a, P> Div<$name<P>> for &'a $name<P>
+            where P: Primitive
+        {
+            type Output = $name<P>;
+
+            fn div(self, rhs: $name<P>) -> $name<P> {
+                let mut data = [<P as Zero>::zero(); $n_channels];
+                for ((n, s), r) in data.iter_mut().zip(self.data.iter()).zip(rhs.data.iter()) {
+                    *n = *s / *r;
+                }
+                $name { data }
+            }
+        }
+
+        impl<'a, P> Div<&'a $name<P>> for $name<P>
+            where P: Primitive
+        {
+            type Output = $name<P>;
+
+            fn div(self, rhs: &'a $name<P>) -> $name<P> {
+                let mut data = [<P as Zero>::zero(); $n_channels];
+                for ((n, s), r) in data.iter_mut().zip(self.data.iter()).zip(rhs.data.iter()) {
+                    *n = *s / *r;
+                }
+                $name { data }
+            }
+        }
+
+        impl<'a, 'b, P> Div<&'a $name<P>> for &'b $name<P>
+            where P: Primitive
+        {
+            type Output = $name<P>;
+
+            fn div(self, rhs: &'a $name<P>) -> $name<P> {
+                let mut data = [<P as Zero>::zero(); $n_channels];
+                for ((n, s), r) in data.iter_mut().zip(self.data.iter()).zip(rhs.data.iter()) {
+                    *n = *s / *r;
+                }
+                $name { data }
+            }
+        }
+
         impl<P> Rem for $name<P>
             where P: Primitive
         {
             type Output = $name<P>;
 
             fn rem(self, rhs: $name<P>) -> $name<P> {
+                let mut data = [<P as Zero>::zero(); $n_channels];
+                for ((n, s), r) in data.iter_mut().zip(self.data.iter()).zip(rhs.data.iter()) {
+                    *n = *s % *r;
+                }
+                $name { data }
+            }
+        }
+
+        impl<'a, P> Rem<$name<P>> for &'a $name<P>
+            where P: Primitive
+        {
+            type Output = $name<P>;
+
+            fn rem(self, rhs: $name<P>) -> $name<P> {
+                let mut data = [<P as Zero>::zero(); $n_channels];
+                for ((n, s), r) in data.iter_mut().zip(self.data.iter()).zip(rhs.data.iter()) {
+                    *n = *s % *r;
+                }
+                $name { data }
+            }
+        }
+
+        impl<'a, P> Rem<&'a $name<P>> for $name<P>
+            where P: Primitive
+        {
+            type Output = $name<P>;
+
+            fn rem(self, rhs: &'a $name<P>) -> $name<P> {
+                let mut data = [<P as Zero>::zero(); $n_channels];
+                for ((n, s), r) in data.iter_mut().zip(self.data.iter()).zip(rhs.data.iter()) {
+                    *n = *s % *r;
+                }
+                $name { data }
+            }
+        }
+
+        impl<'a, 'b, P> Rem<&'a $name<P>> for &'b $name<P>
+            where P: Primitive
+        {
+            type Output = $name<P>;
+
+            fn rem(self, rhs: &'a $name<P>) -> $name<P> {
                 let mut data = [<P as Zero>::zero(); $n_channels];
                 for ((n, s), r) in data.iter_mut().zip(self.data.iter()).zip(rhs.data.iter()) {
                     *n = *s % *r;
@@ -189,6 +371,18 @@ macro_rules! impl_pixels {
         {
             fn one() -> $name<P> {
                 $name { data: [<P as One>::one(); $n_channels ] }
+            }
+        }
+
+        impl<P> Bounded for $name<P>
+            where P: Primitive
+        {
+            fn min_value() -> $name<P> {
+                $name { data: [<P as Bounded>::min_value(); $n_channels ] }
+            }
+
+            fn max_value() -> $name<P> {
+                $name { data: [<P as Bounded>::max_value(); $n_channels ] }
             }
         }
 

--- a/src/core/traits.rs
+++ b/src/core/traits.rs
@@ -1,6 +1,6 @@
 //! Contains the definitions of the various traits used in this crate.
 
-use num_traits::{Bounded, NumAssign, NumCast, NumOps, NumRef, RefNum, Zero};
+use num_traits::{Bounded, NumAssign, NumCast, NumRef, Zero};
 #[cfg(feature = "rand_integration")]
 use rand::{
     distributions::{Distribution, Standard},
@@ -11,16 +11,16 @@ use std::fmt::{Debug, Display};
 
 /// Implemented for primitive pixel types.
 pub trait Primitive:
-    Copy + Clone + Debug + Display + Bounded + NumAssign + RefNum<Self> + NumCast + PartialOrd + Sync + Send
+    Copy + Clone + Debug + Display + Bounded + NumAssign + NumRef + NumCast + PartialOrd + Sync + Send
 {
 }
 
 impl<T> Primitive for T where
-    T: Copy + Clone + Debug + Display + Bounded + NumAssign + RefNum<T> + NumCast + PartialOrd + Sync + Send
+    T: Copy + Clone + Debug + Display + Bounded + NumAssign + NumRef + NumCast + PartialOrd + Sync + Send
 {}
 
 /// This trait must be implemented for the types you want to store in an image.
-pub trait Pixel: Clone + PartialEq + Sync + Send {
+pub trait Pixel: Clone + PartialEq + Sync + Send + Zero {
     /// Type of an individual pixel component.
     type Subpixel: Primitive;
 
@@ -80,12 +80,6 @@ pub trait Region {
     /// Return `true` if the region contains the specified point, `false` otherwise.
     fn contains(&self, x: u32, y: u32) -> bool;
 }
-
-/// Marker trait for pixel types that overload arithmetic operations.
-pub trait PixelOps: Pixel + NumOps {}
-
-/// Marker trait for borrowed pixel types that overload arithmetic operations.
-pub trait PixelOpsRef: PixelOps + NumRef {}
 
 /// Enables casts between pixel types.
 ///

--- a/src/core/traits.rs
+++ b/src/core/traits.rs
@@ -1,6 +1,6 @@
 //! Contains the definitions of the various traits used in this crate.
 
-use num_traits::{NumAssign, NumCast, NumOps, NumRef, RefNum, Zero};
+use num_traits::{Bounded, NumAssign, NumCast, NumOps, NumRef, RefNum, Zero};
 #[cfg(feature = "rand_integration")]
 use rand::{
     distributions::{Distribution, Standard},
@@ -11,12 +11,12 @@ use std::fmt::{Debug, Display};
 
 /// Implemented for primitive pixel types.
 pub trait Primitive:
-    Copy + Clone + Debug + Display + NumAssign + RefNum<Self> + NumCast + PartialOrd + Sync + Send
+    Copy + Clone + Debug + Display + Bounded + NumAssign + RefNum<Self> + NumCast + PartialOrd + Sync + Send
 {
 }
 
 impl<T> Primitive for T where
-    T: Copy + Clone + Debug + Display + NumAssign + RefNum<T> + NumCast + PartialOrd + Sync + Send
+    T: Copy + Clone + Debug + Display + Bounded + NumAssign + RefNum<T> + NumCast + PartialOrd + Sync + Send
 {}
 
 /// This trait must be implemented for the types you want to store in an image.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,8 @@ extern crate num_traits;
 extern crate png;
 #[cfg(feature = "rand_integration")]
 extern crate rand;
-#[cfg(test)] extern crate tempfile;
+#[cfg(test)]
+extern crate tempfile;
 extern crate tiff;
 
 pub mod core;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@ extern crate byteorder;
 #[macro_use]
 extern crate failure;
 #[macro_use]
-extern crate ndarray;
+pub extern crate ndarray;
 extern crate num_traits;
 extern crate png;
 #[cfg(feature = "rand_integration")]


### PR DESCRIPTION
Implement arithmetic operators (`+`, `-`, `*`, `/` and `%`)  on image reference types. It should work between any two image reference types, i.e. `&Image2D<P>` and `&ImageBuffer2D<P>`.