### PR TITLE
Update travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,23 +42,23 @@ jobs:
     - rust: nightly
   fast_finish: true
   include:
-    - stage: pre-build checks
-      rust: stable
-      name: "Rustfmt coding style conformance"
-      addons: { }
-      cache: false
-      before_script: rustup component add rustfmt-preview
-      script:
-        - cargo fmt -- --write-mode=check
-      after_success:
+    #- stage: pre-build checks
+      #rust: stable
+      #name: "Rustfmt coding style conformance"
+      #addons: { }
+      #cache: false
+      #before_script: rustup component add rustfmt
+      #script:
+        #- cargo fmt -- --check
+      #after_success:
     - stage: static analysis
       name: "Clippy"
       addons: { }
-      rust: nightly
+      rust: stable
       cache:
         cargo: true
-      before_script: rustup component add clippy-preview
-      script: cargo clippy -- -D clippy
+      before_script: rustup component add clippy
+      script: cargo clippy -- -D clippy::all
       after_success:
 
 stages:


### PR DESCRIPTION
`rustfmt` and `clippy` components are not preview anymore. I'm also disabling `rustfmt` checks for now.

CI fails on clippy warnings, fixed in #11.